### PR TITLE
fix: Add Discord markdown escaping to prevent formatting issues

### DIFF
--- a/src/simple/handlers.py
+++ b/src/simple/handlers.py
@@ -6,6 +6,8 @@ All event handlers in one beautiful, simple file.
 
 import html
 import os
+import re
+from pathlib import Path
 from typing import Callable, Optional
 
 from event_types import Config, DiscordMessage, EventData, HandlerFunction
@@ -21,19 +23,26 @@ from version import VERSION_STRING
 def handle_pretooluse(data: EventData, config: Config) -> Optional[DiscordMessage]:
     """Handle PreToolUse events."""
     tool_name = data.get("tool_name", "Unknown")
-    
+
     # Skip if tool is disabled
     if not should_process_tool(tool_name, config):
         return None
-    
+
     # Format tool input
     tool_input = data.get("tool_input", {})
     description = format_tool_input(tool_name, tool_input)
-    
-    # Get project name from working directory
-    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
+
+    # Get current working directory
+    try:
+        cwd = Path.cwd()
+        cwd_str = str(cwd)
+        project_name = escape_discord_markdown(cwd.name)
+    except OSError:
+        cwd_str = "Unknown"
+        project_name = "Unknown"
+
     tool_name_escaped = escape_discord_markdown(tool_name)
-    
+
     return {
         "content": f"[{project_name}] About to execute: {tool_name_escaped}",
         "embeds": [{
@@ -42,7 +51,7 @@ def handle_pretooluse(data: EventData, config: Config) -> Optional[DiscordMessag
             "color": 0x3498db,  # Blue
             "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: PreToolUse | {VERSION_STRING}"},
             "fields": [
-                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(cwd_str), "inline": False}
             ]
         }]
     }
@@ -51,19 +60,26 @@ def handle_pretooluse(data: EventData, config: Config) -> Optional[DiscordMessag
 def handle_posttooluse(data: EventData, config: Config) -> Optional[DiscordMessage]:
     """Handle PostToolUse events."""
     tool_name = data.get("tool_name", "Unknown")
-    
+
     # Skip if tool is disabled
     if not should_process_tool(tool_name, config):
         return None
-    
+
     # Format tool response
     tool_response = data.get("tool_response", {})
     description = format_tool_response(tool_name, tool_response)
-    
-    # Get project name from working directory
-    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
+
+    # Get current working directory
+    try:
+        cwd = Path.cwd()
+        cwd_str = str(cwd)
+        project_name = escape_discord_markdown(cwd.name)
+    except OSError:
+        cwd_str = "Unknown"
+        project_name = "Unknown"
+
     tool_name_escaped = escape_discord_markdown(tool_name)
-    
+
     return {
         "content": f"[{project_name}] Completed: {tool_name_escaped}",
         "embeds": [{
@@ -72,7 +88,7 @@ def handle_posttooluse(data: EventData, config: Config) -> Optional[DiscordMessa
             "color": 0x2ecc71,  # Green
             "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: PostToolUse | {VERSION_STRING}"},
             "fields": [
-                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(cwd_str), "inline": False}
             ]
         }]
     }
@@ -82,24 +98,32 @@ def handle_notification(data: EventData, config: Config) -> Optional[DiscordMess
     """Handle Notification events."""
     message = data.get("message", "No message provided")
     message_escaped = escape_discord_markdown(message)
-    
-    # Get project name from working directory
-    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
-    
+
+    # Get current working directory
+    try:
+        cwd = Path.cwd()
+        cwd_str = str(cwd)
+        project_name = escape_discord_markdown(cwd.name)
+    except OSError:
+        cwd_str = "Unknown"
+        project_name = "Unknown"
+
     # Build content with project name and optional user mention
     content = f"[{project_name}] {message_escaped}"
     if user_id := config.get("mention_user_id"):
         content = f"<@{user_id}> {content}"
-    
+
     return {
         "content": content,
         "embeds": [{
             "title": "📢 Notification",
             "description": message_escaped,
             "color": 0xf39c12,  # Orange
-            "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: Notification | {VERSION_STRING}"},
+            "footer": {
+                "text": f"Session: {data.get('session_id', 'unknown')} | Event: Notification | {VERSION_STRING}"
+            },
             "fields": [
-                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(cwd_str), "inline": False}
             ]
         }]
     }
@@ -107,14 +131,20 @@ def handle_notification(data: EventData, config: Config) -> Optional[DiscordMess
 
 def handle_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
     """Handle Stop events."""
-    # Get project name from working directory
-    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
-    
+    # Get current working directory
+    try:
+        cwd = Path.cwd()
+        cwd_str = str(cwd)
+        project_name = escape_discord_markdown(cwd.name)
+    except OSError:
+        cwd_str = "Unknown"
+        project_name = "Unknown"
+
     # Build content with project name and optional user mention
     content = f"[{project_name}] Session Ended"
     if user_id := config.get("mention_user_id"):
         content = f"<@{user_id}> {content}"
-    
+
     return {
         "content": content,
         "embeds": [{
@@ -123,7 +153,7 @@ def handle_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
             "color": 0x95a5a6,  # Gray
             "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: Stop | {VERSION_STRING}"},
             "fields": [
-                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(cwd_str), "inline": False}
             ]
         }]
     }
@@ -131,9 +161,15 @@ def handle_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
 
 def handle_subagent_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
     """Handle SubagentStop events."""
-    # Get project name from working directory
-    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
-    
+    # Get current working directory
+    try:
+        cwd = Path.cwd()
+        cwd_str = str(cwd)
+        project_name = escape_discord_markdown(cwd.name)
+    except OSError:
+        cwd_str = "Unknown"
+        project_name = "Unknown"
+
     return {
         "content": f"[{project_name}] Subagent Completed",
         "embeds": [{
@@ -142,7 +178,7 @@ def handle_subagent_stop(data: EventData, config: Config) -> Optional[DiscordMes
             "color": 0x9b59b6,  # Purple
             "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: SubagentStop | {VERSION_STRING}"},
             "fields": [
-                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(cwd_str), "inline": False}
             ]
         }]
     }
@@ -170,24 +206,29 @@ def get_handler(event_type: str) -> Optional[HandlerFunction]:
 # Utility Functions
 # =============================================================================
 
-def escape_discord_markdown(text: str) -> str:
+def escape_discord_markdown(text: str | None) -> str:
     """Escape Discord markdown special characters.
-    
+
     Prevents Discord from interpreting markdown characters in user content
     like file paths, commands, and error messages.
     """
-    if not isinstance(text, str):
-        text = str(text)
-    
+    if text is None:
+        return ""
+
+    try:
+        if not isinstance(text, str):
+            text = str(text)
+    except (TypeError, ValueError):
+        return "Error: Unable to convert input to string"
+
     # Escape backslashes first to avoid double-escaping
     text = text.replace("\\", "\\\\")
-    
-    # Escape Discord markdown characters
+
+    # Escape Discord markdown characters using regex for efficiency
     # Note: We escape most characters but preserve some formatting where appropriate
-    markdown_chars = "*_`~|>#-=[](){}"
-    for char in markdown_chars:
-        text = text.replace(char, f"\\{char}")
-    
+    markdown_chars = r"[*_`~|>#\-=\[\](){}]"
+    text = re.sub(markdown_chars, r"\\\g<0>", text)
+
     return text
 
 def should_process_event(event_type: str, config: Config) -> bool:
@@ -196,15 +237,15 @@ def should_process_event(event_type: str, config: Config) -> bool:
     if event_states := config.get("event_states"):
         if event_type in event_states:
             return event_states[event_type]
-    
+
     # Check enabled events (legacy whitelist)
     if enabled := config.get("enabled_events"):
         return event_type in enabled
-    
+
     # Check disabled events (legacy blacklist)
     if disabled := config.get("disabled_events"):
         return event_type not in disabled
-    
+
     # Default: all events enabled
     return True
 
@@ -215,7 +256,7 @@ def should_process_tool(tool_name: str, config: Config) -> bool:
     if tool_states := config.get("tool_states"):
         if tool_name in tool_states:
             return tool_states[tool_name]
-    
+
     # Check disabled tools list (legacy)
     disabled_tools = config.get("disabled_tools", [])
     return tool_name not in disabled_tools
@@ -228,19 +269,19 @@ def format_tool_input(tool_name: str, tool_input: dict) -> str:
         content = tool_input.get("content", "")
         size = len(content)
         return f"**File**: `{file_path}`\n**Size**: {size:,} chars"
-    
-    elif tool_name == "Read":
+
+    if tool_name == "Read":
         file_path = escape_discord_markdown(tool_input.get("file_path", "unknown"))
         return f"**File**: `{file_path}`"
-    
-    elif tool_name == "Bash":
+
+    if tool_name == "Bash":
         command = tool_input.get("command", "")
         # Escape Discord markdown characters (this is particularly important for commands with --flags)
         command = escape_discord_markdown(command)
         if len(command) > 100:
             command = command[:100] + "..."
         return f"**Command**: `{command}`"
-    
+
     # Default formatting
     formatted = escape_discord_markdown(str(tool_input))
     if len(formatted) > 500:
@@ -253,16 +294,16 @@ def format_tool_response(tool_name: str, tool_response: dict) -> str:
     if error := tool_response.get("error"):
         # Escape error messages since they can contain user-generated content
         return f"❌ **Error**: {escape_discord_markdown(str(error))}"
-    
+
     if tool_name == "Write":
         return "✅ File written successfully"
-    
-    elif tool_name == "Read":
+
+    if tool_name == "Read":
         return "✅ File read successfully"
-    
-    elif tool_name == "Bash":
+
+    if tool_name == "Bash":
         return "✅ Command executed"
-    
+
     # Default formatting
     formatted = escape_discord_markdown(str(tool_response))
     if len(formatted) > 500:

--- a/src/simple/handlers.py
+++ b/src/simple/handlers.py
@@ -31,17 +31,18 @@ def handle_pretooluse(data: EventData, config: Config) -> Optional[DiscordMessag
     description = format_tool_input(tool_name, tool_input)
     
     # Get project name from working directory
-    project_name = os.path.basename(os.getcwd())
+    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
+    tool_name_escaped = escape_discord_markdown(tool_name)
     
     return {
-        "content": f"[{project_name}] About to execute: {tool_name}",
+        "content": f"[{project_name}] About to execute: {tool_name_escaped}",
         "embeds": [{
-            "title": f"🔵 Starting: {tool_name}",
+            "title": f"🔵 Starting: {tool_name_escaped}",
             "description": description,
             "color": 0x3498db,  # Blue
             "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: PreToolUse | {VERSION_STRING}"},
             "fields": [
-                {"name": "Cwd", "value": os.getcwd(), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
             ]
         }]
     }
@@ -60,17 +61,18 @@ def handle_posttooluse(data: EventData, config: Config) -> Optional[DiscordMessa
     description = format_tool_response(tool_name, tool_response)
     
     # Get project name from working directory
-    project_name = os.path.basename(os.getcwd())
+    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
+    tool_name_escaped = escape_discord_markdown(tool_name)
     
     return {
-        "content": f"[{project_name}] Completed: {tool_name}",
+        "content": f"[{project_name}] Completed: {tool_name_escaped}",
         "embeds": [{
-            "title": f"✅ Completed: {tool_name}",
+            "title": f"✅ Completed: {tool_name_escaped}",
             "description": description,
             "color": 0x2ecc71,  # Green
             "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: PostToolUse | {VERSION_STRING}"},
             "fields": [
-                {"name": "Cwd", "value": os.getcwd(), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
             ]
         }]
     }
@@ -79,12 +81,13 @@ def handle_posttooluse(data: EventData, config: Config) -> Optional[DiscordMessa
 def handle_notification(data: EventData, config: Config) -> Optional[DiscordMessage]:
     """Handle Notification events."""
     message = data.get("message", "No message provided")
+    message_escaped = escape_discord_markdown(message)
     
     # Get project name from working directory
-    project_name = os.path.basename(os.getcwd())
+    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
     
     # Build content with project name and optional user mention
-    content = f"[{project_name}] {message}"
+    content = f"[{project_name}] {message_escaped}"
     if user_id := config.get("mention_user_id"):
         content = f"<@{user_id}> {content}"
     
@@ -92,11 +95,11 @@ def handle_notification(data: EventData, config: Config) -> Optional[DiscordMess
         "content": content,
         "embeds": [{
             "title": "📢 Notification",
-            "description": message,
+            "description": message_escaped,
             "color": 0xf39c12,  # Orange
             "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: Notification | {VERSION_STRING}"},
             "fields": [
-                {"name": "Cwd", "value": os.getcwd(), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
             ]
         }]
     }
@@ -105,7 +108,7 @@ def handle_notification(data: EventData, config: Config) -> Optional[DiscordMess
 def handle_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
     """Handle Stop events."""
     # Get project name from working directory
-    project_name = os.path.basename(os.getcwd())
+    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
     
     # Build content with project name and optional user mention
     content = f"[{project_name}] Session Ended"
@@ -120,7 +123,7 @@ def handle_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
             "color": 0x95a5a6,  # Gray
             "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: Stop | {VERSION_STRING}"},
             "fields": [
-                {"name": "Cwd", "value": os.getcwd(), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
             ]
         }]
     }
@@ -129,7 +132,7 @@ def handle_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
 def handle_subagent_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
     """Handle SubagentStop events."""
     # Get project name from working directory
-    project_name = os.path.basename(os.getcwd())
+    project_name = escape_discord_markdown(os.path.basename(os.getcwd()))
     
     return {
         "content": f"[{project_name}] Subagent Completed",
@@ -139,7 +142,7 @@ def handle_subagent_stop(data: EventData, config: Config) -> Optional[DiscordMes
             "color": 0x9b59b6,  # Purple
             "footer": {"text": f"Session: {data.get('session_id', 'unknown')} | Event: SubagentStop | {VERSION_STRING}"},
             "fields": [
-                {"name": "Cwd", "value": os.getcwd(), "inline": False}
+                {"name": "Cwd", "value": escape_discord_markdown(os.getcwd()), "inline": False}
             ]
         }]
     }
@@ -166,6 +169,26 @@ def get_handler(event_type: str) -> Optional[HandlerFunction]:
 # =============================================================================
 # Utility Functions
 # =============================================================================
+
+def escape_discord_markdown(text: str) -> str:
+    """Escape Discord markdown special characters.
+    
+    Prevents Discord from interpreting markdown characters in user content
+    like file paths, commands, and error messages.
+    """
+    if not isinstance(text, str):
+        text = str(text)
+    
+    # Escape backslashes first to avoid double-escaping
+    text = text.replace("\\", "\\\\")
+    
+    # Escape Discord markdown characters
+    # Note: We escape most characters but preserve some formatting where appropriate
+    markdown_chars = "*_`~|>#-=[](){}"
+    for char in markdown_chars:
+        text = text.replace(char, f"\\{char}")
+    
+    return text
 
 def should_process_event(event_type: str, config: Config) -> bool:
     """Check if event type should be processed."""
@@ -201,25 +224,25 @@ def should_process_tool(tool_name: str, config: Config) -> bool:
 def format_tool_input(tool_name: str, tool_input: dict) -> str:
     """Format tool input for display."""
     if tool_name == "Write":
-        file_path = html.escape(tool_input.get("file_path", "unknown"))
+        file_path = escape_discord_markdown(tool_input.get("file_path", "unknown"))
         content = tool_input.get("content", "")
         size = len(content)
         return f"**File**: `{file_path}`\n**Size**: {size:,} chars"
     
     elif tool_name == "Read":
-        file_path = html.escape(tool_input.get("file_path", "unknown"))
+        file_path = escape_discord_markdown(tool_input.get("file_path", "unknown"))
         return f"**File**: `{file_path}`"
     
     elif tool_name == "Bash":
         command = tool_input.get("command", "")
-        # Escape for safety (even though Discord handles this)
-        command = html.escape(command)
+        # Escape Discord markdown characters (this is particularly important for commands with --flags)
+        command = escape_discord_markdown(command)
         if len(command) > 100:
             command = command[:100] + "..."
         return f"**Command**: `{command}`"
     
     # Default formatting
-    formatted = str(tool_input)
+    formatted = escape_discord_markdown(str(tool_input))
     if len(formatted) > 500:
         formatted = formatted[:500] + "..."
     return formatted
@@ -228,7 +251,8 @@ def format_tool_input(tool_name: str, tool_input: dict) -> str:
 def format_tool_response(tool_name: str, tool_response: dict) -> str:
     """Format tool response for display."""
     if error := tool_response.get("error"):
-        return f"❌ **Error**: {html.escape(str(error))}"
+        # Escape error messages since they can contain user-generated content
+        return f"❌ **Error**: {escape_discord_markdown(str(error))}"
     
     if tool_name == "Write":
         return "✅ File written successfully"
@@ -240,7 +264,7 @@ def format_tool_response(tool_name: str, tool_response: dict) -> str:
         return "✅ Command executed"
     
     # Default formatting
-    formatted = str(tool_response)
+    formatted = escape_discord_markdown(str(tool_response))
     if len(formatted) > 500:
         formatted = formatted[:500] + "..."
     return formatted

--- a/src/simple/handlers.py
+++ b/src/simple/handlers.py
@@ -8,12 +8,14 @@ import html
 import os
 import re
 from pathlib import Path
-from typing import Callable
 
 from event_types import Config, DiscordMessage, EventData, HandlerFunction
 from version import VERSION_STRING
 
 # Python 3.14+ required - pure standard library
+
+# Pre-compiled regex pattern for better performance
+_MARKDOWN_PATTERN = re.compile(r"[*_`~|>#\-=\[\](){}]")
 
 
 # =============================================================================
@@ -159,7 +161,7 @@ def handle_stop(data: EventData, config: Config) -> DiscordMessage | None:
     }
 
 
-def handle_subagent_stop(data: EventData, config: Config) -> DiscordMessage | None:
+def handle_subagent_stop(data: EventData, _config: Config) -> DiscordMessage | None:
     """Handle SubagentStop events."""
     # Get current working directory
     try:
@@ -224,10 +226,8 @@ def escape_discord_markdown(text: str | None) -> str:
     # Escape backslashes first to avoid double-escaping
     text = text.replace("\\", "\\\\")
 
-    # Escape Discord markdown characters using regex for efficiency
-    # Note: We escape most characters but preserve some formatting where appropriate
-    markdown_chars = r"[*_`~|>#\-=\[\](){}]"
-    return re.sub(markdown_chars, r"\\\g<0>", text)
+    # Escape Discord markdown characters using pre-compiled regex for efficiency
+    return _MARKDOWN_PATTERN.sub(r"\\\g<0>", text)
 
 def should_process_event(event_type: str, config: Config) -> bool:
     """Check if event type should be processed."""

--- a/src/simple/handlers.py
+++ b/src/simple/handlers.py
@@ -6,8 +6,6 @@ All event handlers in one beautiful, simple file.
 
 from __future__ import annotations
 
-import html
-import os
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/src/simple/handlers.py
+++ b/src/simple/handlers.py
@@ -4,12 +4,17 @@
 All event handlers in one beautiful, simple file.
 """
 
+from __future__ import annotations
+
 import html
 import os
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from event_types import Config, DiscordMessage, EventData, HandlerFunction
+if TYPE_CHECKING:
+    from event_types import Config, DiscordMessage, EventData, HandlerFunction
+
 from version import VERSION_STRING
 
 # Python 3.14+ required - pure standard library

--- a/src/simple/handlers.py
+++ b/src/simple/handlers.py
@@ -8,7 +8,7 @@ import html
 import os
 import re
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable
 
 from event_types import Config, DiscordMessage, EventData, HandlerFunction
 from version import VERSION_STRING
@@ -20,7 +20,7 @@ from version import VERSION_STRING
 # Event Handlers - Simple, beautiful functions
 # =============================================================================
 
-def handle_pretooluse(data: EventData, config: Config) -> Optional[DiscordMessage]:
+def handle_pretooluse(data: EventData, config: Config) -> DiscordMessage | None:
     """Handle PreToolUse events."""
     tool_name = data.get("tool_name", "Unknown")
 
@@ -57,7 +57,7 @@ def handle_pretooluse(data: EventData, config: Config) -> Optional[DiscordMessag
     }
 
 
-def handle_posttooluse(data: EventData, config: Config) -> Optional[DiscordMessage]:
+def handle_posttooluse(data: EventData, config: Config) -> DiscordMessage | None:
     """Handle PostToolUse events."""
     tool_name = data.get("tool_name", "Unknown")
 
@@ -94,7 +94,7 @@ def handle_posttooluse(data: EventData, config: Config) -> Optional[DiscordMessa
     }
 
 
-def handle_notification(data: EventData, config: Config) -> Optional[DiscordMessage]:
+def handle_notification(data: EventData, config: Config) -> DiscordMessage | None:
     """Handle Notification events."""
     message = data.get("message", "No message provided")
     message_escaped = escape_discord_markdown(message)
@@ -129,7 +129,7 @@ def handle_notification(data: EventData, config: Config) -> Optional[DiscordMess
     }
 
 
-def handle_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
+def handle_stop(data: EventData, config: Config) -> DiscordMessage | None:
     """Handle Stop events."""
     # Get current working directory
     try:
@@ -159,7 +159,7 @@ def handle_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
     }
 
 
-def handle_subagent_stop(data: EventData, config: Config) -> Optional[DiscordMessage]:
+def handle_subagent_stop(data: EventData, config: Config) -> DiscordMessage | None:
     """Handle SubagentStop events."""
     # Get current working directory
     try:
@@ -197,7 +197,7 @@ HANDLERS: dict[str, HandlerFunction] = {
 }
 
 
-def get_handler(event_type: str) -> Optional[HandlerFunction]:
+def get_handler(event_type: str) -> HandlerFunction | None:
     """Get handler for event type."""
     return HANDLERS.get(event_type)
 
@@ -227,16 +227,13 @@ def escape_discord_markdown(text: str | None) -> str:
     # Escape Discord markdown characters using regex for efficiency
     # Note: We escape most characters but preserve some formatting where appropriate
     markdown_chars = r"[*_`~|>#\-=\[\](){}]"
-    text = re.sub(markdown_chars, r"\\\g<0>", text)
-
-    return text
+    return re.sub(markdown_chars, r"\\\g<0>", text)
 
 def should_process_event(event_type: str, config: Config) -> bool:
     """Check if event type should be processed."""
     # Check individual event states (new style - highest priority)
-    if event_states := config.get("event_states"):
-        if event_type in event_states:
-            return event_states[event_type]
+    if (event_states := config.get("event_states")) and event_type in event_states:
+        return event_states[event_type]
 
     # Check enabled events (legacy whitelist)
     if enabled := config.get("enabled_events"):
@@ -253,9 +250,8 @@ def should_process_event(event_type: str, config: Config) -> bool:
 def should_process_tool(tool_name: str, config: Config) -> bool:
     """Check if tool should be processed."""
     # Check individual tool states (new style - highest priority)
-    if tool_states := config.get("tool_states"):
-        if tool_name in tool_states:
-            return tool_states[tool_name]
+    if (tool_states := config.get("tool_states")) and tool_name in tool_states:
+        return tool_states[tool_name]
 
     # Check disabled tools list (legacy)
     disabled_tools = config.get("disabled_tools", [])


### PR DESCRIPTION
This PR implements Discord markdown escaping to fix formatting issues when notifications contain special characters like double underscores.

## Changes
- Add `escape_discord_markdown()` function to handle Discord special characters
- Apply escaping to project names, tool names, file paths, commands, and error messages
- Prevent double underscores (__) and other markdown chars from causing formatting issues
- Particularly important for commands with --flags like --no-project

## Testing
The implementation has been syntax-checked and is ready for integration testing.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * Discordメッセージ内の予期しないマークダウン装飾を防ぐため、動的テキスト（プロジェクト名、ツール名、コマンド入力、ファイルパス、エラーメッセージなど）が自動的にエスケープされるようになりました。
  * 作業ディレクトリの取得処理が改善され、例外発生時のフォールバック対応が追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->